### PR TITLE
bug fixed

### DIFF
--- a/unmt.sh
+++ b/unmt.sh
@@ -89,14 +89,14 @@ then
   #wget -c http://data.statmt.org/wmt17/translation-task/news.2017.fr.shuffled.gz
 
   # Germen data
-  wget -c http://www.statmt.org/wmt14/training-monolingual-news-crawl/news.2007.de.shuffled.gz
-  wget -c http://www.statmt.org/wmt14/training-monolingual-news-crawl/news.2008.de.shuffled.gz
-  wget -c http://www.statmt.org/wmt14/training-monolingual-news-crawl/news.2009.de.shuffled.gz
-  wget -c http://www.statmt.org/wmt14/training-monolingual-news-crawl/news.2010.de.shuffled.gz
-  wget -c http://www.statmt.org/wmt14/training-monolingual-news-crawl/news.2011.de.shuffled.gz
-  wget -c http://www.statmt.org/wmt14/training-monolingual-news-crawl/news.2012.de.shuffled.gz
-  wget -c http://www.statmt.org/wmt14/training-monolingual-news-crawl/news.2013.de.shuffled.gz
-  wget -c http://www.statmt.org/wmt15/training-monolingual-news-crawl-v2/news.2014.de.shuffled.v2.gz
+  # wget -c http://www.statmt.org/wmt14/training-monolingual-news-crawl/news.2007.de.shuffled.gz
+  # wget -c http://www.statmt.org/wmt14/training-monolingual-news-crawl/news.2008.de.shuffled.gz
+  # wget -c http://www.statmt.org/wmt14/training-monolingual-news-crawl/news.2009.de.shuffled.gz
+  # wget -c http://www.statmt.org/wmt14/training-monolingual-news-crawl/news.2010.de.shuffled.gz
+  # wget -c http://www.statmt.org/wmt14/training-monolingual-news-crawl/news.2011.de.shuffled.gz
+  # wget -c http://www.statmt.org/wmt14/training-monolingual-news-crawl/news.2012.de.shuffled.gz
+  # wget -c http://www.statmt.org/wmt14/training-monolingual-news-crawl/news.2013.de.shuffled.gz
+  # wget -c http://www.statmt.org/wmt15/training-monolingual-news-crawl-v2/news.2014.de.shuffled.v2.gz
   # wget -c http://data.statmt.org/wmt16/translation-task/news.2015.de.shuffled.gz
   # wget -c http://data.statmt.org/wmt17/translation-task/news.2016.de.shuffled.gz
   # wget -c http://data.statmt.org/wmt18/translation-task/news.2017.de.shuffled.deduped.gz
@@ -112,7 +112,6 @@ then
     fi
   done
   
-
   if ! [[ -f "$SRC_RAW" && -f "$TRG_RAW" ]]; then
     echo "Concatenating monolingual data..."
     cat $(ls news*$SRC* | grep -v gz) > $SRC_RAW
@@ -127,7 +126,6 @@ then
   python3 $based_dir/UNMT-SPR/scripts/clean_mono_data.py $SRC_RAW $SRC_CLEANED ../Models/langid.bin $SRC_LANG
   python3 $based_dir/UNMT-SPR/scripts/clean_mono_data.py $TRG_RAW $TRG_CLEANED ../Models/langid.bin $TRG_LANG
 
-  
   echo "Downloading test data..."
   cd ../Test
   wget -c http://data.statmt.org/wmt17/translation-task/dev.tgz
@@ -198,7 +196,6 @@ then
   rm train_data_bpe.vocab # train_data_bpe.whole
   rm ../Train/combined.bpe
 
-  
   echo "Training KenLM..."
   cd ../Train
   $MOSES_HOME/bin/lmplz -o 5 --prune 0 1 1 2 2 < $SRC_TC > ../Models/lm.arpa.$SRC
@@ -206,7 +203,6 @@ then
   $MOSES_HOME/bin/lmplz -o 5 --prune 0 1 1 2 2 < $TRG_TC > ../Models/lm.arpa.$TRG 
   $MOSES_HOME/bin/build_binary ../Models/lm.arpa.$TRG ../Models/lm.bin.$TRG
   
-
   echo "Spliting files..." # this step will split the whole training data into several files, each of 4,000 ,000 lines.
   mv $SRC_TC ./tok
   mv $TRG_TC ./tok

--- a/unmt.sh
+++ b/unmt.sh
@@ -1,6 +1,6 @@
 set -e
 
-based_dir=/home/lyy/usLearning
+based_dir=~
 
 SRC_LANG=en
 TRG_LANG=fr
@@ -11,8 +11,8 @@ LANG_PAIR=$SRC_LANG-$TRG_LANG
 MOSES_HOME=$based_dir/mosesdecoder
 FASTTEXT_HOME=$based_dir/fasttext
 VECMAP_HOME=$based_dir/vecmap
-THREADS=10
-GPU_LIST=[0,2]
+THREADS=40
+GPU_LIST=[0,1,2,3]
 
 TOKENIZER=$MOSES_HOME/scripts/tokenizer/tokenizer.perl
 NORM_PUNC=$MOSES_HOME/scripts/tokenizer/normalize-punctuation.perl
@@ -181,7 +181,7 @@ then
 
   echo "Training cross-lingual word embeddings..."
   cd ../Vocab
-  python3 $VECMAP_HOME/map_embeddings.py --unsupervised $SRC_LANG.emb.vec $TRG_LANG.emb.vec $LANG_PAIR.$SRC_LANG.vec $LANG_PAIR.$TRG_LANG.vec # 1111
+  python3 $VECMAP_HOME/map_embeddings.py --unsupervised $SRC_LANG.emb.vec $TRG_LANG.emb.vec $LANG_PAIR.$SRC_LANG.vec $LANG_PAIR.$TRG_LANG.vec
 
   echo "Inferring dictionary..."
   python3 $based_dir/UNMT-SPR/scripts/build_dic_from_emb_multichoice.py --src_embeddings $LANG_PAIR.$SRC_LANG.vec --trg_embeddings $LANG_PAIR.$TRG_LANG.vec --dictionary $SRC_LANG-$TRG_LANG.dic \


### PR DESCRIPTION
I am sorry there still remains concealed bugs:
1. When training cross-lingual word embeddings, the script loads the vectors both $SRC and $SRC.
2. When apply bpe in test/valid corpus, the script loads unexist file.

I notice that the script train bpe in .tok but apply in .tc, is there a reason? Or this is just another mistake.